### PR TITLE
fix(commonjs dir imports) Fixes imports that specify directories only.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -144,6 +144,9 @@ export function bundle(options: Options): BundleResult {
 
     if (!allFiles) {
         assert(fs.existsSync(mainFile), 'main does not exist: ' + mainFile);
+        if (fs.lstatSync(mainFile).isDirectory()) {
+            mainFile = path.join(mainFile, 'index.d.ts');
+        }
     }
 
     if (headerPath) {
@@ -702,7 +705,12 @@ export function bundle(options: Options): BundleResult {
                     };
                     res.lines.push(modLine);
 
-                    const full = path.resolve(path.dirname(file), impPath + '.d.ts');
+                    let full = path.resolve(path.dirname(file), impPath);
+                    if(fs.existsSync(full) && fs.lstatSync(full).isDirectory()) {
+                      full = path.join(full, 'index.d.ts');
+                    } else {
+                      full = path.resolve(path.dirname(file), impPath + '.d.ts');
+                    }
                     trace(' - import relative %s (%s)', moduleName, full);
 
                     pushUnique(res.relativeImports, full);

--- a/test/expected/commonjs/foo-mx.d.ts
+++ b/test/expected/commonjs/foo-mx.d.ts
@@ -1,0 +1,35 @@
+// Dependencies for this module:
+//   ../../src/typings/external.d.ts
+
+declare module 'foo-mx' {
+    import exp = require('foo-mx/lib/exported-sub');
+    import mod1 = require('external1');
+    export import Foo = require('foo-mx/Foo');
+    export function run(foo?: Foo): Foo;
+    export function flep(): exp.ExternalContainer;
+    export function bar(): mod1.SomeType;
+}
+
+declare module 'foo-mx/lib/exported-sub' {
+    import Foo = require('foo-mx/Foo');
+    import mod2 = require('external2');
+    export class ExternalContainer {
+        something: mod2.AnotherType;
+    }
+    export function bar(foo: Foo): string;
+    export function bazz(value: string, option?: boolean): string;
+}
+
+declare module 'foo-mx/Foo' {
+    class Foo {
+            foo: string;
+            constructor(secret?: string);
+            /**
+                * Bars the foo.
+                */
+            barFoo(): void;
+            /** Foos the baz. */
+            fooBaz(): void;
+    }
+    export = Foo;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -331,7 +331,30 @@ describe('dts bundle', function () {
 		]);
 		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
 	});
-    
+
+	testit('commonjs', function (actDir, expDir) {
+		var result = dts.bundle({
+			baseDir: actDir,
+			name: 'foo-mx',
+			main: actDir,
+			newline: '\n',
+            		verbose: true,
+            		headerPath: "none"
+		});
+		var name = 'foo-mx.d.ts';
+		var actualFile = path.join(actDir, name);
+        	assert.isTrue(result.emitted, "not emit " + actualFile);
+		var expectedFile = path.join(expDir, name);
+		assertFiles(actDir, [
+			name,
+			'index.d.ts',
+			'Foo.d.ts',
+			'lib/exported-sub.d.ts',
+			'lib/only-internal.d.ts'
+		]);
+		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
+	});
+
   	//testit('includeExclude_cli', function (actDir, expDir) {  }); // No exclude options available from CLI.
 
 


### PR DESCRIPTION
If file is a directory then assume that what is meant is the index file in the directory.

Resolves Issue 38